### PR TITLE
Update em-scripts.js

### DIFF
--- a/packages/scripts/bin/em-scripts.js
+++ b/packages/scripts/bin/em-scripts.js
@@ -11,7 +11,7 @@ const argv = require('yargs-parser')(args);
 
 if (['dev', 'build'].includes(script)) {
     const result = spawn.sync(
-        'node ',
+        'node',
         [path.resolve(__dirname, `../commands/${script}.js`), '--port', argv.port],
         {
             stdio: 'inherit'


### PR DESCRIPTION
fix error: Error: spawnSync node  ENOENT in macos